### PR TITLE
Fixed several spelling mistakes in comments

### DIFF
--- a/ack.c
+++ b/ack.c
@@ -29,7 +29,7 @@ void acknowledgeJob(job *job) {
 
 /* ------------------------- Garbage collection ----------------------------- */
 
-/* Return the next milliseconds unix time where the next GC attept for this
+/* Return the next milliseconds unix time where the next GC attempt for this
  * job should be performed. */
 mstime_t getNextGCRetryTime(job *job) {
     mstime_t period = JOB_GC_RETRY_MIN_PERIOD * (1 << job->gc_retry);
@@ -108,8 +108,8 @@ void tryJobGC(RedisModuleCtx *ctx, job *job) {
 /* This function is called by cluster.c every time we receive a GOTACK message
  * about a job we know. */
 void gotAckReceived(RedisModuleCtx *ctx, const char *sender, job *job, int known) {
-    /* A dummy ACK is an acknowledged job that we created just becakse a client
-     * send us ACKJOB about a job we were not aware. */
+    /* A dummy ACK is an acknowledged job that we created just because a client
+     * sent us ACKJOB about a job we were not aware. */
     int dummy_ack = raxSize(job->nodes_delivered) == 0;
 
     RedisModule_Log(ctx,"verbose",
@@ -248,12 +248,12 @@ int ackjobCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  *
  * Performs a fast acknowledge of the specified jobs.
  * A fast acknowledge does not really attempt to make sure all the nodes
- * that may have a copy recive the ack. The job is just discarded and
+ * that may have a copy receive the ack. The job is just discarded and
  * a best-effort DELJOB is sent to all the nodes that may have a copy
  * without caring if they receive or not the message.
  *
  * This command will more likely result in duplicated messages delivery
- * during network partiitons, but uses less messages compared to ACKJOB.
+ * during network partitions, but uses less messages compared to ACKJOB.
  *
  * If a job is not known, a cluster-wide DELJOB is broadcasted.
  *

--- a/aof.c
+++ b/aof.c
@@ -4,7 +4,7 @@
 
 #include "disque.h"
 
-/* AOF implemention is work in progress. */
+/* AOF implementation is work in progress. */
 
 void AOFLoadJob(job *job) { UNUSED(job); }
 void AOFDelJob(job *job) { UNUSED(job); }
@@ -44,7 +44,7 @@ void AOFDelJob(job *job) {
     decrRefCount(jobid);
 }
 
-/* Emit a DELJOB command, since ths is how we handle acknowledged jobs from
+/* Emit a DELJOB command, since this is how we handle acknowledged jobs from
  * the point of view of AOF. We are not interested in loading back acknowledged
  * jobs, nor we include them on AOF rewrites, since ACKs garbage collection
  * works anyway if nodes forget about ACKs and dropping ACKs is not a safety

--- a/cluster.c
+++ b/cluster.c
@@ -207,7 +207,7 @@ void GOTJOBcallback(RedisModuleCtx *ctx, const char *sender_id, uint8_t msgtype,
 
 /* SETACK message: set the job as acknowledged and bring forward the
  * garbage collection of the job if needed, either replying with a GOTACK
- * message or by continuing the GC oruselves if we are in a better condition
+ * message or by continuing the GC ourself if we are in a better condition
  * than the sender. */
 void SETACKcallback(RedisModuleCtx *ctx, const char *sender_id, uint8_t msgtype, const unsigned char *payload, uint32_t len) {
     if (validateMessage(ctx,sender_id,payload,len,msgtype) == 0)
@@ -257,7 +257,7 @@ void SETACKcallback(RedisModuleCtx *ctx, const char *sender_id, uint8_t msgtype,
          *    because the sender has just a dummy ACK.
          * 2) Or, we prevented the sender from finishing the GC since
          *    we are not replying with GOTACK, and we need to take
-         *    responsability to evict the job in the cluster. */
+         *    responsibility to evict the job in the cluster. */
         tryJobGC(ctx,j);
     }
 }
@@ -472,7 +472,7 @@ void clusterBroadcastMessage(RedisModuleCtx *ctx, rax *nodes, int type, const un
  *
  * If there are already nodes that received the message, additional
  * 'repl' nodes will be added to the list (if possible), and the message
- * broadcasted again to all the nodes that may already have the message,
+ * broadcast again to all the nodes that may already have the message,
  * plus the new ones.
  *
  * However for nodes for which we already have the GOTJOB reply, we flag
@@ -707,7 +707,7 @@ void clusterBroadcastPause(RedisModuleCtx *ctx, const char *qname, size_t qnamel
 }
 
 /* Send a YOURJOBS message to the specified node, with a serialized copy of
- * the jobs referneced by the 'jobs' array and containing 'count' jobs. */
+ * the jobs referenced by the 'jobs' array and containing 'count' jobs. */
 void clusterSendYourJobs(RedisModuleCtx *ctx, const char *node, job **jobs, uint32_t count) {
     unsigned char buf[sizeof(clusterSerializedJobMessage)], *payload;
     clusterSerializedJobMessage *hdr = (clusterSerializedJobMessage*) buf;

--- a/job.c
+++ b/job.c
@@ -30,7 +30,7 @@
  *
  * The TTL is a big endian 16 bit unsigned number ceiled to 2^16-1
  * if greater than that, and is only used in order to expire ACKs
- * when the job is no longer avaialbe. It represents the TTL of the
+ * when the job is no longer available. It represents the TTL of the
  * original job in *minutes*, not seconds, and is encoded in as a
  * 4 digits hexadecimal number.
  *
@@ -100,7 +100,7 @@ void generateJobID(char *id, int ttl, int retry) {
  * as hex big endian number in the Job ID. The function is only used for this
  * but is more generic. 'p' points to the first digit for 'count' hex digits.
  * The number is assumed to be stored in big endian format. For each byte
- * the first hex char is the most significative. If invalid digits are found
+ * the first hex char is the most significant. If invalid digits are found
  * considered to be zero, however errno is set to EINVAL if this happens. */
 uint64_t hexToInt(const char *p, size_t count) {
     uint64_t value = 0;
@@ -133,7 +133,7 @@ uint64_t hexToInt(const char *p, size_t count) {
  * However comparing nodes just by node ID means that a given node is always
  * greater than the other. So before comparing the node IDs, we mix the IDs
  * with the pseudorandom part of the Job ID, using the XOR function. This way
- * the comparision depends on the job. */
+ * the comparison depends on the job. */
 int compareNodeIDsByJob(const char *nodea, const char *nodeb, job *j) {
     int i;
     char ida[REDISMODULE_NODE_ID_LEN], idb[REDISMODULE_NODE_ID_LEN];
@@ -210,7 +210,7 @@ job *createJob(const char *id, int state, int ttl, int retry) {
     j->nodes_delivered = raxNew();
     j->nodes_confirmed = NULL; /* Only created later on-demand. */
     j->awakeme = 0; /* Not yet registered in awakeme skiplist. */
-    /* Number of NACKs and additiona deliveries start at zero and
+    /* Number of NACKs and additional deliveries start at zero and
      * are incremented as QUEUED messages are received or sent. */
     j->num_nacks = 0;
     j->num_deliv = 0;
@@ -293,7 +293,7 @@ int unregisterJob(RedisModuleCtx *ctx, job *j) {
 }
 
 /* Return the job state as a C string pointer. This is mainly useful for
- * reporting / debugign tasks. */
+ * reporting / debugging tasks. */
 char *jobStateToString(int state) {
     char *states[] = {"wait-repl","active","queued","acked"};
     if (state < 0 || state > JOB_STATE_ACKED) return "unknown";
@@ -333,7 +333,7 @@ int jobStateFromString(char *state) {
 /* Ask the system to update the time the job will be called again as an
  * argument of awakeJob() in order to handle delayed tasks for this job.
  * If 'at' is zero, the function computes the next time we should check
- * the job status based on the next quee time (qtime), expire time, garbage
+ * the job status based on the next queue time (qtime), expire time, garbage
  * collection if it's an ACK, and so forth.
  *
  * Otherwise if 'at' is non-zero, it's up to the caller to set the time
@@ -382,7 +382,7 @@ void updateJobRequeueTime(job *j, mstime_t qtime) {
     updateJobAwakeTime(j,0);
 }
 
-/* Job comparision inside the awakeme skiplist: by awakeme time. If it is the
+/* Job comparison inside the awakeme skiplist: by awakeme time. If it is the
  * same jobs are compared by ctime. If the same again, by job ID. */
 int skiplistCompareJobsToAwake(const void *a, const void *b) {
     const job *ja = a, *jb = b;
@@ -531,7 +531,7 @@ void processJobs(RedisModuleCtx *ctx, void *clientData) {
         current = next;
     }
 
-    /* Try to block between 1 and 100 millseconds depending on how near
+    /* Try to block between 1 and 100 milliseconds depending on how near
      * in time is the next async event to process. Note that because of
      * received commands or change in state jobs state may be modified so
      * we set a max time of 100 milliseconds to wakeup anyway. */
@@ -609,8 +609,8 @@ char *serializeSdsString(char *p, sds s) {
  * job: uint32_t little endian len + actual bytes of the job body.
  *
  * nodes: List of nodes that may have a copy of the message. uint32_t
- * little endian with the count of N node names followig. Then N
- * fixed lenght node names of CLUSTER_NODE_NAMELEN characters each.
+ * little endian with the count of N node names following. Then N
+ * fixed length node names of CLUSTER_NODE_NAMELEN characters each.
  *
  * The message is concatenated to the existing sds string 'jobs'.
  * Just use sdsempty() as first argument to get a single job serialized.
@@ -691,7 +691,7 @@ sds serializeJob(sds jobs, job *j, int sertype) {
     }
     raxStop(&ri);
 
-    /* Make sure we wrote exactly the intented number of bytes. */
+    /* Make sure we wrote exactly the intended number of bytes. */
     RedisModule_Assert(len == (size_t)(p-msg));
     return jobs;
 }
@@ -1413,7 +1413,7 @@ int showCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 /* DELJOB jobid_1 jobid_2 ... jobid_N
  *
- * Evict (and possibly remove from queue) all the jobs in memeory
+ * Evict (and possibly remove from queue) all the jobs in memory
  * matching the specified job IDs. Jobs are evicted whatever their state
  * is, since this command is mostly used inside the AOF or for debugging
  * purposes.

--- a/queue.c
+++ b/queue.c
@@ -17,7 +17,7 @@ void signalQueueAsReady(RedisModuleCtx *ctx, queue *q);
 
 /* ------------------------ Low level queue functions ----------------------- */
 
-/* Job comparision inside a skiplist: by ctime, if ctime is the same by
+/* Job comparison inside a skiplist: by ctime, if ctime is the same by
  * job ID. */
 int skiplistCompareJobsInQueue(const void *a, const void *b) {
     const job *ja = a, *jb = b;
@@ -331,10 +331,10 @@ void cleanupClientBlockedForJobs(RedisModuleCtx *ctx, RedisModuleBlockedClient *
     raxRemove(BlockedClients,(unsigned char*)&bc,sizeof(bc),NULL);
 }
 
-/* Handle blocking if GETJOB fonud no jobs in the specified queues.
+/* Handle blocking if GETJOB found no jobs in the specified queues.
  *
  * 1) We set q->clients to the list of clients blocking for this queue
- *    (the value fo the list items is a BlockedClientData structure).
+ *    (the value of the list items is a BlockedClientData structure).
  * 2) We set BlockedClients as well, as a dictionary of queues a client
  *    is blocked for. So we can resolve queues from clients. This is useful
  *    in order to clear the blocked client list when the client
@@ -481,7 +481,7 @@ unsigned long getQueueValidResponders(queue *q) {
  *
  * Calling this function may result into NEEDJOBS messages send to specific
  * nodes that are remembered as potential sources for messages in this queue,
- * or more rarely into NEEDJOBS messages to be broadcasted cluster-wide in
+ * or more rarely into NEEDJOBS messages to be broadcast cluster-wide in
  * order to discover new nodes that may be source of messages.
  *
  * This function in called in two different contests:
@@ -494,7 +494,7 @@ unsigned long getQueueValidResponders(queue *q) {
  * for case 3 instead type is set to NEEDJOBS_REACHED_ZERO, and in this
  * case the node may send a NEEDJOBS message to the set of known sources
  * for this queue, regardless of needjobs_adhoc_time value (that is, without
- * trying to trottle the requests, since there is an active flow of messages
+ * trying to throttle the requests, since there is an active flow of messages
  * between this node and source nodes).
  */
 
@@ -573,7 +573,7 @@ void needJobsForQueue(RedisModuleCtx *ctx, queue *q, int type) {
     }
 }
 
-/* needJobsForQueue() wrapper taking a queue name insteead of a queue
+/* needJobsForQueue() wrapper taking a queue name instead of a queue
  * structure. The queue will be created automatically if non existing. */
 void needJobsForQueueName(RedisModuleCtx *ctx, RedisModuleString *qname, int type) {
     size_t namelen;
@@ -951,7 +951,7 @@ int dequeueCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  *
  * Normally jobs are returned from the oldest to the newest (according to the
  * job creation time field), however if "count" is negative , jobs are
- * returend from newset to oldest instead.
+ * returned from newset to oldest instead.
  *
  * Each job is returned as a two elements array with the Job ID and body. */
 int qpeekCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -998,8 +998,8 @@ int qpeekCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  * Postpone the job requeue time in the future so that we'll wait the retry
  * time before enqueueing again.
  *
- * Also, as a side effect of callign this command, a WORKING message gets
- * broadcasted to all the other nodes that have a copy according to our local
+ * Also, as a side effect of calling this command, a WORKING message gets
+ * broadcast to all the other nodes that have a copy according to our local
  * job information.
  *
  * Return how much time the worker likely have before the next requeue event

--- a/rax.c
+++ b/rax.c
@@ -259,7 +259,7 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
     size_t curlen = raxNodeCurrentLength(n);
     n->size++;
     size_t newlen = raxNodeCurrentLength(n);
-    n->size--; /* For now restore the orignal size. We'll update it only on
+    n->size--; /* For now restore the original size. We'll update it only on
                   success at the end. */
 
     /* Alloc the new child we will link to 'n'. */


### PR DESCRIPTION
This pull-request fixes several minor spelling mistakes in the codebase.

I've not scanned the whole code, but if this is accepted I will go back and re-read the source again, this was just an initial pass fixing those things that jumped out quickly/immediately.

